### PR TITLE
Removal of blue separator outline code.

### DIFF
--- a/kdecoration/breezedecoration.cpp
+++ b/kdecoration/breezedecoration.cpp
@@ -634,16 +634,6 @@ namespace Breeze
 
         }
 
-        const QColor outlineColor( this->outlineColor() );
-        if( !c->isShaded() && outlineColor.isValid() )
-        {
-            // outline
-            painter->setRenderHint( QPainter::Antialiasing, false );
-            painter->setBrush( Qt::NoBrush );
-            painter->setPen( outlineColor );
-            painter->drawLine( titleRect.bottomLeft(), titleRect.bottomRight() );
-        }
-
         painter->restore();
 
         // draw caption


### PR DESCRIPTION
It doesn't fit the proposed styling of future breeze updates nor is it common to have it enabled.